### PR TITLE
Pass version string as preprocessor define

### DIFF
--- a/kernel/version.cc
+++ b/kernel/version.cc
@@ -1,0 +1,28 @@
+/*
+ *  yosys -- Yosys Open SYnthesis Suite
+ *
+ *  Copyright (C) 2012  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+#include "kernel/yosys.h"
+
+YOSYS_NAMESPACE_BEGIN
+
+extern const char *yosys_version_str;
+
+const char *yosys_version_str = YOSYS_VER_STR;
+
+YOSYS_NAMESPACE_END

--- a/misc/create_vcxsrc.sh
+++ b/misc/create_vcxsrc.sh
@@ -2,8 +2,9 @@
 
 set -ex
 vcxsrc="$1-$2"
-yosysver="$2"
 gitsha="$3"
+yosysver="$2"
+yosysverstr="$yosysver (git sha1 $gitsha, Visual Studio)"
 
 rm -rf YosysVS-Tpl-v1.zip YosysVS
 wget http://www.clifford.at/yosys/nogit/YosysVS-Tpl-v1.zip
@@ -17,7 +18,7 @@ mv YosysVS "$vcxsrc"
 	head -n$n "$vcxsrc"/YosysVS/YosysVS.vcxproj
 	egrep '\.(h|hh|hpp|inc)$' srcfiles.txt | sed 's,.*,<ClInclude Include="../yosys/&" />,'
 	egrep -v '\.(h|hh|hpp|inc)$' srcfiles.txt | sed 's,.*,<ClCompile Include="../yosys/&" />,'
-	echo '<ClCompile Include="../yosys/kernel/version.cc" />'
+	echo "<ClCompile><PreprocessorDefinitions>YOSYS_VER_STR=\"${yosysverstr}\";%(PreprocessorDefinitions)</PreprocessorDefinitions></ClCompile>"
 	tail -n +$((n+1)) "$vcxsrc"/YosysVS/YosysVS.vcxproj
 } > "$vcxsrc"/YosysVS/YosysVS.vcxproj.new
 
@@ -26,9 +27,6 @@ mv "$vcxsrc"/YosysVS/YosysVS.vcxproj.new "$vcxsrc"/YosysVS/YosysVS.vcxproj
 mkdir -p "$vcxsrc"/yosys
 tar -cf - -T srcfiles.txt | tar -xf - -C "$vcxsrc"/yosys
 cp -r share "$vcxsrc"/
-
-echo "namespace Yosys { extern const char *yosys_version_str; const char *yosys_version_str=\"Yosys" \
-		"$yosysver (git sha1 $gitsha, Visual Studio)\"; }" > "$vcxsrc"/yosys/kernel/version.cc
 
 cat > "$vcxsrc"/readme-git.txt << EOT
 Want to use a git working copy for the yosys source code?


### PR DESCRIPTION
Instead of creating `kernel/version_XXXXX.cc` in the Makefile.

This is just another small simplification of the Makefile..